### PR TITLE
Master and Worker script directory clash

### DIFF
--- a/PAT/MASTER_scripts/runall
+++ b/PAT/MASTER_scripts/runall
@@ -40,7 +40,7 @@ WORKER_TMP_DIR=$(awk '(/^WORKER_TMP_DIR/){for (i=2; i<=NF; i++) print $i}' confi
 
 CONF_DIRS=$(awk '(/^CONF_DIRS/){for (i=2; i<=NF; i++) print $i}' config)
 
-OUTDIR=$(pwd)/tmp
+OUTDIR=$(pwd)/mst_tmp
 rm -rf $OUTDIR
 mkdir $OUTDIR
 mkdir $OUTDIR/jobhistory
@@ -56,7 +56,7 @@ function on_exit()
 echo "Exiting Script ..." 
 $MASTER_SCRIPT_DIR/killjob
 killall -e killjvms
-rm -rf tmp  
+rm -rf mst_tmp  
 }
 
 getJobid(){

--- a/PAT/WORKER_scripts/perftool
+++ b/PAT/WORKER_scripts/perftool
@@ -25,8 +25,8 @@
 
 
 #! /bin/bash
-rm -rf tmp
-mkdir tmp
+rm -rf perf_tmp
+mkdir perf_tmp
 rm -rf $1/perfout
 
 function on_exit()
@@ -37,6 +37,6 @@ killall -SIGINT -e perf
 trap 'on_exit; exit' SIGINT SIGKILL SIGTERM
 while(true)do
 
-perf record -a -F 1000 -o tmp/$(date +%s) sleep 5 2> /dev/null
+perf record -a -F 1000 -o perf_tmp/$(date +%s) sleep 5 2> /dev/null
 sleep 1
 done

--- a/PAT/WORKER_scripts/postperf
+++ b/PAT/WORKER_scripts/postperf
@@ -26,17 +26,17 @@
 
 #! /bin/bash
 
-if [ -d "./tmp" ]; then
-for i in $(ls -r tmp)
+if [ -d "./perf_tmp" ]; then
+for i in $(ls -r perf_tmp)
 do
-	rm -f ./tmp/$i
+	rm -f ./perf_tmp/$i
 	break
 done
-for i in $(ls tmp)
+for i in $(ls perf_tmp)
 do
-(perf report -i tmp/$i 2>/dev/null) 1>&1 | awk -v outfile=$i -v host=$(hostname) '(!/^#/ && !/^$/){if($1 >= 0.01)print host,outfile,$0 }' | sed -e 's/\s\+//7g' -e 's/%//g' >> $1/perfout
+(perf report -i perf_tmp/$i 2>/dev/null) 1>&1 | awk -v outfile=$i -v host=$(hostname) '(!/^#/ && !/^$/){if($1 >= 0.01)print host,outfile,$0 }' | sed -e 's/\s\+//7g' -e 's/%//g' >> $1/perfout
 
 done
-rm -rf tmp
+rm -rf perf_tmp
 rm -rf /tmp/perf-*.map
 fi


### PR DESCRIPTION
Addressed issue raised by Takuma concerning a scenario where
$MASTER_SCRIPT_DIR and $WORKER_SCRIPT_DIR are the same directory. fixed
this by changing the name of "tmp" sub-directories created in each case
to a more specific name. "mst_tmp" and "perf_tmp"