### PR TITLE
fix bug at perf_module

### DIFF
--- a/PAT-post-processing/perf_module.py
+++ b/PAT-post-processing/perf_module.py
@@ -95,7 +95,11 @@ class Perf(pat_base):
     def normalize(self, cpu_obj):
         """Look up %idle inside the cpu for the same timestamp and normalize \
         sum of cycles"""
-        idle_dict = dict(zip(cpu_obj.time_stamp_array, cpu_obj.idle_percent))
+        time_stamp_set = set(cpu_obj.time_stamp_array)
+        idle_dict = {}
+        for time_stamp in time_stamp_set:
+            index = cpu_obj.time_stamp_array.index(time_stamp)
+            idle_dict[time_stamp] = cpu_obj.idle_percent[index]
         for self.ind, self.row in enumerate(self.data_array):
             try:
                 self.ts = int(self.row[1])


### PR DESCRIPTION
generate idle_dict at normalize using %idle of all cpus rather than the last cpu.